### PR TITLE
Move @loadable/component to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@loadable/babel-plugin": "^5.13.2",
     "@loadable/server": "^5.15.0",
     "@loadable/webpack-plugin": "^5.15.0",
-    "@loadable/component": "^5.15.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.10",
@@ -33,7 +32,8 @@
   "license": "MIT",
   "peerDependencies": {
     "gatsby": "^2.12.1 || ^3.0.0",
-    "react-dom": "^16.12.0 || ^17.0.1"
+    "react-dom": "^16.12.0 || ^17.0.1",
+    "@loadable/component": "^5.15.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
@loadable/component might conflict with the local version, so it's better to move it to the peer dependencies section.